### PR TITLE
Add GitHub CI for automatic building of docker images and automatic deployment

### DIFF
--- a/.github/workflows/docker-on-push.yml
+++ b/.github/workflows/docker-on-push.yml
@@ -36,3 +36,8 @@ jobs:
             ${{ github.repository }}/:latest
             ${{ github.repository }}/:commit-${{ github.sha }}
 
+      - name: Send POST Request to deploy changes
+        run: |
+          curl -X POST ${{ secrets.DEPLOY_URL }}          
+
+

--- a/.github/workflows/docker-on-push.yml
+++ b/.github/workflows/docker-on-push.yml
@@ -1,0 +1,38 @@
+name: Build and Push to Docker Hub on changes to main branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GHCR_TOKEN}} # needs read:packages, write:packages. delete:packages
+
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ github.repository }}/:main
+            ${{ github.repository }}/:latest
+            ${{ github.repository }}/:commit-${{ github.sha }}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   sealbot:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image:  ghcr.io/n0201/public_sealbot:main
     container_name: sealbot
     restart: unless-stopped
     environment:


### PR DESCRIPTION
This Github Actions config _should_ work. Here's what you'll need to do **before** merging.

- Go to https://github.com/settings/tokens/new and create a access token with `read:packages`, `write:packages` and `delete:packages` rights. Set the token to never expire.
- Next go to https://github.com/n0201/public_sealbot/settings/secrets/actions and create a new **Repository Secret** named `GHCR_TOKEN`. Set the value as the token you created previously.
- Create another **Repository Secret** named `DEPLOY_URL`. Set the value as the URL I sent you privately.

Now any pushes you make to the main branch should trigger a new docker image being built and it being deployed to my server.